### PR TITLE
Redesign landing page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -20,7 +19,7 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  @apply bg-gradient-to-br from-sky-50 to-purple-100 text-foreground;
+  font-family: var(--font-sans), sans-serif;
+  font-size: 18px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,9 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -24,9 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${inter.variable} antialiased`}>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,101 +2,54 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+    <div className="min-h-screen flex flex-col">
+      <header className="flex items-center justify-between px-6 py-4">
+        <div className="bg-white/80 rounded-full shadow px-3 py-1 text-2xl font-semibold text-indigo-600">
+          M
         </div>
+      </header>
+      <main className="flex flex-col items-center flex-1 px-6 text-center gap-24">
+        <section className="mt-10 flex flex-col items-center gap-6 max-w-2xl">
+          <h1 className="text-4xl font-bold">Твой психологический ИИ-ассистент</h1>
+          <button className="bg-gradient-to-r from-indigo-400 to-purple-500 text-white text-lg px-8 py-4 rounded-full shadow-lg hover:shadow-xl transition">
+            Начать чат
+          </button>
+        </section>
+        <section className="grid gap-6 sm:grid-cols-3 w-full max-w-5xl">
+          <div className="bg-white/70 backdrop-blur p-6 rounded-2xl shadow flex flex-col items-center text-center">
+            <span className="text-3xl">💬</span>
+            <h3 className="mt-4 font-semibold">Дружелюбный диалог</h3>
+          </div>
+          <div className="bg-white/70 backdrop-blur p-6 rounded-2xl shadow flex flex-col items-center text-center">
+            <span className="text-3xl">⏱️</span>
+            <h3 className="mt-4 font-semibold">Быстрые ответы</h3>
+          </div>
+          <div className="bg-white/70 backdrop-blur p-6 rounded-2xl shadow flex flex-col items-center text-center">
+            <span className="text-3xl">🔒</span>
+            <h3 className="mt-4 font-semibold">Конфиденциально</h3>
+          </div>
+        </section>
+        <section className="grid gap-6 sm:grid-cols-3 w-full max-w-5xl">
+          <div className="bg-white/80 p-6 rounded-2xl shadow hover:shadow-md transition text-left">
+            <p className="italic">“Очень помогает разобраться в себе.”</p>
+            <span className="block mt-4 font-medium text-right">Анна</span>
+          </div>
+          <div className="bg-white/80 p-6 rounded-2xl shadow hover:shadow-md transition text-left">
+            <p className="italic">“Ответы приходят мгновенно, как будто меня слушают.”</p>
+            <span className="block mt-4 font-medium text-right">Игорь</span>
+          </div>
+          <div className="bg-white/80 p-6 rounded-2xl shadow hover:shadow-md transition text-left">
+            <p className="italic">“Чувствую поддержку в любое время дня.”</p>
+            <span className="block mt-4 font-medium text-right">Елена</span>
+          </div>
+        </section>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
+      <footer className="py-6 text-center flex flex-col gap-2 items-center">
+        <p className="text-sm">© 2024 MindMate</p>
+        <div className="flex gap-4 text-xl">
+          <a href="#" aria-label="Telegram">📱</a>
+          <a href="#" aria-label="VK">📘</a>
+        </div>
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- switch to Inter font and lighten global styles
- update global background to a blue-purple gradient
- redesign the landing page content with centered hero, feature cards, testimonials and footer

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883998e679c8327a5623e62009f0f78