### PR TITLE
Add blinking cursor input

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,16 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes blink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.blinking-caret {
+  animation: blink 1s step-end infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
+import { useState } from "react";
 
 export default function Home() {
+  const [focused, setFocused] = useState(false);
   return (
     <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
@@ -50,6 +52,15 @@ export default function Home() {
             Read our docs
           </a>
         </div>
+        <p className="text-lg mt-6">
+          Готов выслушать тебя
+          {!focused && <span className="blinking-caret">|</span>}
+        </p>
+        <input
+          className="mt-3 border border-gray-400 p-2 transition-[width] duration-500 w-[200px] focus:w-[280px] outline-none"
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+        />
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
         <a


### PR DESCRIPTION
## Summary
- add typewriter-style blinking cursor CSS
- show 'Готов выслушать тебя' with blinking cursor
- grow the input width when focused and hide the initial blinking cursor

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884aad2076c8327b9467e6bce581833